### PR TITLE
fixing UnserializableExceptionException for exceptions with a cause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build.sh
 *.iml
 *.ipr
 *.iws
+/out

--- a/README.md
+++ b/README.md
@@ -6,12 +6,3 @@ This project uses [Gradle](http://www.gradle.org/ "Home - Gradle") to build. You
 
     ./gradlew test
 
-### Git Submodules
-
-This project will not build without initialising submodules. After you have cloned and checked out a branch, you must run
-
-    git submodule init
-
-And…
-
-    git submodule update

--- a/module/remote-core/src/main/groovy/groovyx/remote/RemoteControlException.groovy
+++ b/module/remote-core/src/main/groovy/groovyx/remote/RemoteControlException.groovy
@@ -20,7 +20,10 @@ class RemoteControlException extends RuntimeException {
 	static public final long serialVersionUID = 1L
 	
 	RemoteControlException(message, Throwable cause = null) {
-		super(message as String, cause)
+		super(message as String)
+		if (cause) {
+			initCause(cause)
+		}
 	}
 
 }

--- a/module/remote-core/src/test/groovy/groovyx/remote/SmokeTests.groovy
+++ b/module/remote-core/src/test/groovy/groovyx/remote/SmokeTests.groovy
@@ -113,7 +113,23 @@ class SmokeTests extends GroovyTestCase {
 			remote.exec { throw new IncorrectClosureArgumentsException({ 1 }, [System.out], OutputStream)}
 		}
 	}
-	
+
+	void testUnserializableExceptionWithCause() {
+		def cause = null
+		try {
+			remote.exec {
+				def e = new IncorrectClosureArgumentsException({ 1 }, [System.out], OutputStream)
+				e.initCause(new Exception('cause foo'))
+				throw e
+			}
+		} catch (RemoteException e) {
+			cause = e.cause.cause
+			assert cause.class == UnserializableExceptionException // also
+			assert cause.message.endsWith('message = "cause foo"')
+		}
+		assert cause
+	}
+
 	void testCanSpecifyToUseNullIfReturnWasUnserializable() {
 		remote.useNullIfResultWasUnserializable = true
 		try {


### PR DESCRIPTION
This version of the fix avoids the duplicate constructors and uses tabs instead of spaces.
