### PR TITLE
Changed visibility of CommandChainInvoker and CommandInvoker

### DIFF
--- a/module/remote-core/src/main/groovy/groovyx/remote/server/CommandChainInvoker.groovy
+++ b/module/remote-core/src/main/groovy/groovyx/remote/server/CommandChainInvoker.groovy
@@ -22,8 +22,8 @@ class CommandChainInvoker {
 	
 	final ClassLoader parentLoader
 	final CommandChain commandChain
-	
-	private CommandChainInvoker(ClassLoader parentLoader, CommandChain commandChain) {
+
+	CommandChainInvoker(ClassLoader parentLoader, CommandChain commandChain) {
 		this.parentLoader = parentLoader
 		this.commandChain = commandChain
 	}
@@ -34,7 +34,7 @@ class CommandChainInvoker {
 		def lastCommand = commandChain.commands.last()
 		
 		for (command in commandChain.commands) {
-			lastResult = new CommandInvoker(parentLoader, command).invokeAgainst(delegate, arg)
+			lastResult = createInvoker(parentLoader, command).invokeAgainst(delegate, arg)
 			
 			if (command != lastCommand) {
 				if (lastResult.thrown) {
@@ -49,5 +49,9 @@ class CommandChainInvoker {
 		}
 		
 		lastResult
+	}
+
+	protected createInvoker(ClassLoader loader, Command command) {
+		new CommandInvoker(parentLoader, command)
 	}
 }

--- a/module/remote-core/src/main/groovy/groovyx/remote/server/CommandInvoker.groovy
+++ b/module/remote-core/src/main/groovy/groovyx/remote/server/CommandInvoker.groovy
@@ -27,7 +27,7 @@ class CommandInvoker {
 	final Class rootClass
 	final List supportClasses
 	
-	private CommandInvoker(ClassLoader parentLoader, Command command) {
+	CommandInvoker(ClassLoader parentLoader, Command command) {
 		this.parentLoader = parentLoader
 		this.command = command
 	}
@@ -44,8 +44,12 @@ class CommandInvoker {
 				thrown = thrown.cause
 			}
 
-			Result.forThrown(StackTraceUtils.deepSanitize(thrown))
+			resultForThrown(thrown)
 		}
+	}
+
+	protected Result resultForThrown(Throwable thrown) {
+		Result.forThrown(StackTraceUtils.deepSanitize(thrown))
 	}
 	
 	def instantiate() {


### PR DESCRIPTION
This pull request contains changes that aim to make it easier to extend CommandInvoker and CommandChainInvoker. GAE doesn't allow to directly use the LogManager class which is being used by the StackTraceUtils while sanitizing the stack trace in CommandInvoker#invokeAgainst. Thanks to the changes from this pull request there is now much less code needed to change how the throwable is being handled in CommandInvoker#invokeAgainst.
