### PR TITLE
Fixed CommandGenerator to properly retrieve class bytes from jar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ subprojects {
 
 project(':module:remote-core') {
 	dependencies {
-		testCompile project(":module:remote-transport-local")
+		testCompile project(":module:remote-transport-local"), project(":module:remote-using-lib")
 	}
 }
 
@@ -204,6 +204,15 @@ project(':module:remote-transport-http') {
 
 project(':module:remote-transport-local') {
 	dependencies {
+		compile project(":module:remote-core")
+	}
+}
+
+project(':module:remote-using-lib') {
+	apply plugin: "groovy"
+
+	dependencies {
+		groovy groovyDependency
 		compile project(":module:remote-core")
 	}
 }

--- a/module/remote-core/src/main/groovy/groovyx/remote/client/CommandGenerator.groovy
+++ b/module/remote-core/src/main/groovy/groovyx/remote/client/CommandGenerator.groovy
@@ -79,7 +79,7 @@ class CommandGenerator {
 			throw new IllegalStateException("Could not find class file for class ${closureClass}")
 		}
 		
-		new File(classFileResource.file).bytes
+		classFileResource.bytes
 	}
 	
 	protected String getClassFileName(Class closureClass) {

--- a/module/remote-core/src/test/groovy/groovyx/remote/SmokeTests.groovy
+++ b/module/remote-core/src/test/groovy/groovyx/remote/SmokeTests.groovy
@@ -316,5 +316,9 @@ class SmokeTests extends GroovyTestCase {
 	void testCanUseSpreadMapOperator() {
 		remote.exec {  new HashMap(*:[a: 1, b: 2]) }
 	}
+
+	void testExternalLibrariesExecutingCodeOnRemote() {
+		assert new RemoteCallingClass(remote).multiplyBy2OnRemote(3) == 6
+	}
 	
 }

--- a/module/remote-using-lib/src/main/groovy/groovyx/remote/RemoteCallingClass.groovy
+++ b/module/remote-using-lib/src/main/groovy/groovyx/remote/RemoteCallingClass.groovy
@@ -1,0 +1,15 @@
+package groovyx.remote
+
+import groovyx.remote.client.RemoteControl
+
+class RemoteCallingClass {
+	RemoteControl remote
+
+	RemoteCallingClass(RemoteControl remote) {
+		this.remote = remote
+	}
+
+	int multiplyBy2OnRemote(int multiplied) {
+		remote.exec { multiplied * 2 }
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include "module:remote-core", 
         "module:remote-transport-local",
         "module:remote-transport-http",
+		"module:remote-using-lib",
         "doc:manual",
         "doc:site"


### PR DESCRIPTION
Fixes a problem where a closure passed to RemoteControl's exec() which is coming from a jar file causes getting class bytes in CommandGenerator to fail.
